### PR TITLE
Fixed card image heights

### DIFF
--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -808,12 +808,17 @@ main {
 
   & > a > img {
     display: block;
-    height: auto;
-    opacity: 1;
+    height: 14rem;
+    object-fit: cover;
     width: 100%;
+    opacity: 1;
 
     &:hover {
       opacity: 0.7;
+    }
+
+    @include media-breakpoint-down(md) {
+      height: 15rem;
     }
   }
 


### PR DESCRIPTION
The height of images in cards was inconsistent. This ensures the height is the same, regardless of what image is used.